### PR TITLE
feat(connectors): add Status task to observe connector freshness without triggering a sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## What
 
 - Provides plugin components under `io.kestra.plugin.fivetran`.
-- Includes classes such as `Sync`, `SyncResponse`, `ConnectorStatusResponse`, `ConnectorResponse`.
+- Includes classes such as `Sync`, `Status`, `SyncResponse`, `ConnectorStatusResponse`, `ConnectorResponse`.
 
 ## Why
 
@@ -21,7 +21,8 @@ Single-module plugin. Source packages under `io.kestra.plugin`:
 
 ### Key Plugin Classes
 
-- `io.kestra.plugin.fivetran.connectors.Sync`
+- `io.kestra.plugin.fivetran.connectors.Sync`: triggers a connector sync and optionally waits for completion.
+- `io.kestra.plugin.fivetran.connectors.Status`: reads the current status of one or more connectors via a single GET per connector, without triggering a sync. Computes a `fresh` verdict per connector from `succeededAt`/`syncFrequency`/`slack`, and by default (`wait: true`) polls until every connector is fresh or fails fast on a paused/broken connector, up to `maxDuration`. Emits one lineage asset per connector destination schema when `assets.enableAuto` is set, with the asset id composed as `groupId.schema` (falling back to `connectorId.schema` when `groupId` is absent) so connectors sharing a schema never collide.
 
 ### Project Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Single-module plugin. Source packages under `io.kestra.plugin`:
 ### Key Plugin Classes
 
 - `io.kestra.plugin.fivetran.connectors.Sync`: triggers a connector sync and optionally waits for completion.
-- `io.kestra.plugin.fivetran.connectors.Status`: reads the current status of one or more connectors via a single GET per connector, without triggering a sync. Computes a `fresh` verdict per connector from `succeededAt`/`syncFrequency`/`slack`, and by default (`wait: true`) polls until every connector is fresh or fails fast on a paused/broken connector, up to `maxDuration`. Emits one lineage asset per connector destination schema when `assets.enableAuto` is set, with the asset id composed as `groupId.schema` (falling back to `connectorId.schema` when `groupId` is absent) so connectors sharing a schema never collide.
+- `io.kestra.plugin.fivetran.connectors.Status`: reads the current status of one or more connectors via a single GET per connector, without triggering a sync. Computes a `fresh` verdict per connector from `succeededAt`/`syncFrequency`/`slack`, and by default (`wait: true`) polls until every connector is fresh or fails fast on a paused/broken connector, up to `maxDuration`. Emits one lineage asset per connector destination schema when `assets.enableAuto` is set, with the asset id composed as `groupId.schema` (falling back to `connectorId.schema` when `groupId` is absent) so connectors sharing a schema never collide. Each segment is sanitized on its own before being joined with `.`, so a `.` inside a raw segment (e.g. schema `google_sheets.destination`) can never be mistaken for the delimiter.
 
 ### Project Structure
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 ## What
 
 - Provides plugin components under `io.kestra.plugin.fivetran`.
-- Includes classes such as `Sync`, `SyncResponse`, `ConnectorStatusResponse`, `ConnectorResponse`.
+- Includes classes such as `Sync`, `Status`, `SyncResponse`, `ConnectorStatusResponse`, `ConnectorResponse`.
 
 ## Documentation
 * Full documentation can be found under [kestra.io/docs](https://kestra.io/docs)

--- a/src/main/java/io/kestra/plugin/fivetran/AbstractFivetranConnection.java
+++ b/src/main/java/io/kestra/plugin/fivetran/AbstractFivetranConnection.java
@@ -191,13 +191,10 @@ public abstract class AbstractFivetranConnection extends Task {
     }
 
     /**
-     * URL-encodes a connector ID before it is interpolated into a Fivetran API path, so an id containing
-     * reserved URL characters cannot alter the request path. Shared by every task/trigger that builds a
-     * connector path, so the GET status read and the POST sync trigger stay consistent.
-     * <p>
-     * {@link URLEncoder} applies {@code application/x-www-form-urlencoded} rules, which encode a space as
-     * {@code +}. That is wrong for a URL path segment, where {@code +} is a literal character and a space
-     * must become {@code %20}, so the {@code +} produced by the encoder is corrected afterward.
+     * URL-encodes a connector ID before it is interpolated into a Fivetran API path, so reserved URL
+     * characters cannot alter the request path. Shared by the GET status read and the POST sync trigger.
+     * {@link URLEncoder} uses form-encoding, which emits {@code +} for a space, so it is corrected to the
+     * path-segment {@code %20}.
      */
     protected static String encodeConnectorId(String connectorId) {
         return URLEncoder.encode(connectorId, StandardCharsets.UTF_8).replace("+", "%20");

--- a/src/main/java/io/kestra/plugin/fivetran/AbstractFivetranConnection.java
+++ b/src/main/java/io/kestra/plugin/fivetran/AbstractFivetranConnection.java
@@ -194,9 +194,13 @@ public abstract class AbstractFivetranConnection extends Task {
      * URL-encodes a connector ID before it is interpolated into a Fivetran API path, so an id containing
      * reserved URL characters cannot alter the request path. Shared by every task/trigger that builds a
      * connector path, so the GET status read and the POST sync trigger stay consistent.
+     * <p>
+     * {@link URLEncoder} applies {@code application/x-www-form-urlencoded} rules, which encode a space as
+     * {@code +}. That is wrong for a URL path segment, where {@code +} is a literal character and a space
+     * must become {@code %20}, so the {@code +} produced by the encoder is corrected afterward.
      */
     protected static String encodeConnectorId(String connectorId) {
-        return URLEncoder.encode(connectorId, StandardCharsets.UTF_8);
+        return URLEncoder.encode(connectorId, StandardCharsets.UTF_8).replace("+", "%20");
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/fivetran/AbstractFivetranConnection.java
+++ b/src/main/java/io/kestra/plugin/fivetran/AbstractFivetranConnection.java
@@ -3,6 +3,9 @@ package io.kestra.plugin.fivetran;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 import org.apache.hc.core5.http.Method;
@@ -26,6 +29,8 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.retrys.Exponential;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.RetryUtils;
+import io.kestra.plugin.fivetran.models.Connector;
+import io.kestra.plugin.fivetran.models.ConnectorResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
@@ -54,6 +59,7 @@ public abstract class AbstractFivetranConnection extends Task {
         description = "Required; paired with `apiSecret` for HTTP Basic authentication."
     )
     @NotNull
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     Property<String> apiKey;
 
@@ -62,6 +68,7 @@ public abstract class AbstractFivetranConnection extends Task {
         description = "Required secret token used with `apiKey` for Basic authentication."
     )
     @NotNull
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     Property<String> apiSecret;
 
@@ -158,6 +165,38 @@ public abstract class AbstractFivetranConnection extends Task {
         } catch (IOException e) {
             throw new RuntimeException("Error executing HTTP request", e);
         }
+    }
+
+    /**
+     * Reads a connector's current status via GET, without triggering a sync.
+     *
+     * @param runContext The run context used to render properties and build the HTTP client.
+     * @param connectorId The already-rendered Fivetran connector ID.
+     * @return The connector as returned by the Fivetran API.
+     */
+    protected Connector fetchConnector(RunContext runContext, String connectorId)
+        throws IllegalVariableEvaluationException, HttpClientException {
+        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
+            .uri(
+                URI.create(
+                    runContext.render(this.getBaseUrl()).as(String.class).orElseThrow() +
+                        "/v2/connectors/" + encodeConnectorId(connectorId)
+                )
+            )
+            .method("GET");
+
+        HttpResponse<ConnectorResponse> response = this.request(runContext, requestBuilder, ConnectorResponse.class);
+
+        return response.getBody().getData();
+    }
+
+    /**
+     * URL-encodes a connector ID before it is interpolated into a Fivetran API path, so an id containing
+     * reserved URL characters cannot alter the request path. Shared by every task/trigger that builds a
+     * connector path, so the GET status read and the POST sync trigger stay consistent.
+     */
+    protected static String encodeConnectorId(String connectorId) {
+        return URLEncoder.encode(connectorId, StandardCharsets.UTF_8);
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/fivetran/connectors/Status.java
+++ b/src/main/java/io/kestra/plugin/fivetran/connectors/Status.java
@@ -1,0 +1,477 @@
+package io.kestra.plugin.fivetran.connectors;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.http.client.HttpClientException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.assets.Asset;
+import io.kestra.core.models.assets.Custom;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.runners.AssetEmit;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.Await;
+import io.kestra.plugin.fivetran.AbstractFivetranConnection;
+import io.kestra.plugin.fivetran.models.Connector;
+import io.kestra.plugin.fivetran.models.ConnectorStatusResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import static io.kestra.core.utils.Rethrow.throwSupplier;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Read the status of one or more Fivetran connectors, optionally gating on freshness",
+    description = "Reads each connector's current status through a single GET call per connector. Never triggers a sync. By default (`wait: true`), polls until every connector is fresh so downstream tasks only run once the underlying data is up to date; set `wait: false` for a single read-only snapshot."
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            code = """
+                id: fivetran_status_gate
+                namespace: company.team
+
+                tasks:
+                  - id: wait_until_fresh
+                    type: io.kestra.plugin.fivetran.connectors.Status
+                    apiKey: "{{ secret('FIVETRAN_API_KEY') }}"
+                    apiSecret: "{{ secret('FIVETRAN_API_SECRET') }}"
+                    connectorIds:
+                      - connector_id_1
+                      - connector_id_2
+                    slack: PT10M
+
+                  - id: run_after_fresh_data
+                    type: io.kestra.plugin.core.log.Log
+                    message: "Connectors are fresh: {{ outputs.wait_until_fresh.connectors }}"
+                """
+        ),
+        @Example(
+            full = true,
+            code = """
+                id: fivetran_status_snapshot
+                namespace: company.team
+
+                tasks:
+                  - id: status
+                    type: io.kestra.plugin.fivetran.connectors.Status
+                    apiKey: "{{ secret('FIVETRAN_API_KEY') }}"
+                    apiSecret: "{{ secret('FIVETRAN_API_SECRET') }}"
+                    connectorIds:
+                      - connector_id_1
+                      - connector_id_2
+                    wait: false
+                """
+        )
+    }
+)
+public class Status extends AbstractFivetranConnection implements RunnableTask<Status.Output> {
+    private static final String CONNECTED_SETUP_STATE = "connected";
+    private static final String TABLE_ASSET_TYPE = "io.kestra.plugin.ee.assets.Table";
+
+    @Schema(
+        title = "Connector IDs",
+        description = "Identifiers of the Fivetran connectors whose status should be read."
+    )
+    @NotNull
+    @PluginProperty(group = "main")
+    private Property<List<String>> connectorIds;
+
+    @Schema(
+        title = "Freshness slack",
+        description = "Buffer added on top of each connector's `syncFrequency` when deciding whether its last sync is fresh. Default is no buffer (`PT0S`)."
+    )
+    @Builder.Default
+    @PluginProperty(group = "reliability")
+    Property<Duration> slack = Property.ofValue(Duration.ZERO);
+
+    @Schema(
+        title = "Wait until every connector is fresh",
+        description = "When true (default), poll all connectors until each one is fresh, capped by `maxDuration`. Set to false to read each connector once and report its status without gating."
+    )
+    @Builder.Default
+    @PluginProperty(group = "execution")
+    Property<Boolean> wait = Property.ofValue(true);
+
+    @Schema(
+        title = "Maximum wait duration",
+        description = "Upper bound for waiting when `wait` is true. Default is 1 hour."
+    )
+    @Builder.Default
+    @PluginProperty(group = "execution")
+    Property<Duration> maxDuration = Property.ofValue(Duration.ofHours(1));
+
+    @Schema(
+        title = "Poll frequency",
+        description = "Interval between connector status checks while waiting for freshness. Default is 30 seconds. Must not be greater than `maxDuration`."
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    Property<Duration> pollFrequency = Property.ofValue(Duration.ofSeconds(30));
+
+    @Schema(
+        title = "Allow terminal-state connectors instead of failing fast",
+        description = "When `wait` is true, a paused connector or one whose setup is not `connected` can never become fresh, so the task fails fast by default instead of polling forever. Set to true to report such connectors as not-fresh instead, letting the gate wait out `maxDuration`."
+    )
+    @Builder.Default
+    @PluginProperty(group = "reliability")
+    Property<Boolean> allowFailed = Property.ofValue(false);
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        Logger logger = runContext.logger();
+        List<String> rConnectorIds = runContext.render(this.connectorIds).asList(String.class);
+        if (rConnectorIds.isEmpty()) {
+            throw new IllegalArgumentException("connectorIds must not be empty");
+        }
+        for (int i = 0; i < rConnectorIds.size(); i++) {
+            String connectorId = rConnectorIds.get(i);
+            if (connectorId == null || connectorId.isBlank()) {
+                throw new IllegalArgumentException("connectorIds[" + i + "] must not be null or blank");
+            }
+        }
+        Duration rSlack = runContext.render(this.slack).as(Duration.class).orElse(Duration.ZERO);
+        boolean rWait = runContext.render(this.wait).as(Boolean.class).orElse(true);
+        boolean rAllowFailed = runContext.render(this.allowFailed).as(Boolean.class).orElse(false);
+
+        if (!rWait) {
+            Map<String, Connector> connectors = fetchAll(runContext, rConnectorIds);
+            Map<String, ConnectorState> states = toStates(connectors, rSlack);
+            logStates(logger, states);
+            emitAssets(runContext, connectors, states);
+            return Output.builder().connectors(states).build();
+        }
+
+        Duration rPollFrequency = runContext.render(this.pollFrequency).as(Duration.class).orElse(Duration.ofSeconds(30));
+        if (rPollFrequency.isNegative() || rPollFrequency.isZero()) {
+            throw new IllegalArgumentException("pollFrequency must be a positive duration, but was " + rPollFrequency);
+        }
+        Duration rMaxDuration = runContext.render(this.maxDuration).as(Duration.class).orElse(Duration.ofHours(1));
+        if (rPollFrequency.compareTo(rMaxDuration) > 0) {
+            throw new IllegalArgumentException(
+                "pollFrequency (" + rPollFrequency + ") must not be greater than maxDuration (" + rMaxDuration + ")"
+            );
+        }
+
+        AtomicReference<Exception> lastTransientError = new AtomicReference<>();
+        AtomicReference<Map<String, ConnectorState>> lastSeenStates = new AtomicReference<>();
+        AtomicReference<Map<String, Connector>> lastSeenConnectors = new AtomicReference<>();
+
+        Map<String, ConnectorState> finalStates;
+        try {
+            finalStates = Await.until(
+                throwSupplier(() ->
+                {
+                    Map<String, Connector> current;
+                    try {
+                        current = fetchAll(runContext, rConnectorIds);
+                    } catch (Exception e) {
+                        // A transient read failure does not mean the connector is stale, so keep polling.
+                        if (isRetriableTransientError(e, "GET")) {
+                            lastTransientError.set(e);
+                            logger.warn("Could not read connector status, retrying on next poll: {}", e.getMessage());
+                            return null;
+                        }
+                        throw e;
+                    }
+
+                    Map<String, ConnectorState> states = toStates(current, rSlack);
+                    lastSeenStates.set(states);
+                    lastSeenConnectors.set(current);
+
+                    for (Map.Entry<String, Connector> entry : current.entrySet()) {
+                        String connectorId = entry.getKey();
+                        Connector connector = entry.getValue();
+                        ConnectorState state = states.get(connectorId);
+
+                        // Freshness can never be determined without a sync_frequency, so waiting for it would poll forever.
+                        if (state.getFresh() == null) {
+                            throw new IllegalStateException(
+                                "Connector '" + connectorId + "' has no sync_frequency reported by Fivetran, so freshness cannot be computed"
+                            );
+                        }
+
+                        if (!rAllowFailed && isTerminal(connector)) {
+                            throw new IllegalStateException(
+                                "Connector '" + connectorId + "' cannot become fresh: " + terminalReason(connector)
+                            );
+                        }
+                    }
+
+                    boolean allFresh = states.values().stream().allMatch(state -> Boolean.TRUE.equals(state.getFresh()));
+                    return allFresh ? states : null;
+                }),
+                rPollFrequency,
+                rMaxDuration
+            );
+        } catch (TimeoutException e) {
+            throw new TimeoutException(timeoutMessage(rMaxDuration, lastSeenStates.get(), lastTransientError.get()));
+        }
+
+        logStates(logger, finalStates);
+        emitAssets(runContext, lastSeenConnectors.get(), finalStates);
+        return Output.builder().connectors(finalStates).build();
+    }
+
+    private Map<String, Connector> fetchAll(RunContext runContext, List<String> connectorIds)
+        throws IllegalVariableEvaluationException, HttpClientException {
+        Map<String, Connector> connectors = new LinkedHashMap<>();
+        for (String connectorId : connectorIds) {
+            connectors.put(connectorId, this.fetchConnector(runContext, connectorId));
+        }
+        return connectors;
+    }
+
+    private static Map<String, ConnectorState> toStates(Map<String, Connector> connectors, Duration slack) {
+        ZonedDateTime now = ZonedDateTime.now();
+        Map<String, ConnectorState> states = new LinkedHashMap<>();
+        connectors.forEach((id, connector) -> states.put(id, toConnectorState(connector, now, slack)));
+        return states;
+    }
+
+    private static ConnectorState toConnectorState(Connector connector, ZonedDateTime now, Duration slack) {
+        ConnectorStatusResponse status = connector.getStatus();
+
+        return ConnectorState.builder()
+            .id(connector.getId())
+            .name(connector.getName())
+            .paused(connector.getPaused())
+            .syncFrequency(connector.getSyncFrequency())
+            .scheduleType(connector.getScheduleType())
+            .succeededAt(connector.getSucceededAt())
+            .failedAt(connector.getFailedAt())
+            .completedDate(connector.completedDate())
+            .hasFailed(connector.hasFailed())
+            .syncState(status != null ? status.getSyncState() : null)
+            .setupState(status != null ? status.getSetupState() : null)
+            .schemaStatus(status != null ? status.getSchemaStatus() : null)
+            .fresh(computeFresh(connector.getSucceededAt(), connector.hasFailed(), connector.getSyncFrequency(), slack, now))
+            .build();
+    }
+
+    /**
+     * Null when Fivetran reports no sync_frequency, since freshness cannot be related to a frequency that
+     * doesn't exist. Otherwise, fresh only if the last completion was a success within syncFrequency + slack
+     * of {@code now}, boundary inclusive: a success landing exactly on the threshold still counts as fresh.
+     * Package-private and parameterized on {@code now} so the boundary can be asserted deterministically in
+     * tests instead of racing the real clock.
+     */
+    static Boolean computeFresh(ZonedDateTime succeededAt, boolean hasFailed, Integer syncFrequency, Duration slack, ZonedDateTime now) {
+        if (syncFrequency == null) {
+            return null;
+        }
+
+        return succeededAt != null
+            && !hasFailed
+            && !succeededAt.isBefore(now.minusMinutes(syncFrequency).minus(slack));
+    }
+
+    // A paused connector, or one whose setup is not connected (broken, incomplete, bad-auth), can never
+    // sync again on its own, so it can never become fresh.
+    private static boolean isTerminal(Connector connector) {
+        return Boolean.TRUE.equals(connector.getPaused()) || !CONNECTED_SETUP_STATE.equals(setupState(connector));
+    }
+
+    private static String terminalReason(Connector connector) {
+        return "paused=" + connector.getPaused() + ", setupState=" + setupState(connector);
+    }
+
+    private static String setupState(Connector connector) {
+        ConnectorStatusResponse status = connector.getStatus();
+        return status != null ? status.getSetupState() : null;
+    }
+
+    private static String timeoutMessage(Duration maxDuration, Map<String, ConnectorState> lastSeenStates, Exception lastTransientError) {
+        String stale = lastSeenStates == null
+            ? ""
+            : lastSeenStates.entrySet().stream()
+                .filter(entry -> !Boolean.TRUE.equals(entry.getValue().getFresh()))
+                .map(entry -> entry.getKey() + " (last succeeded at " + entry.getValue().getSucceededAt() + ")")
+                .collect(Collectors.joining(", "));
+
+        StringBuilder message = new StringBuilder("Connector(s) did not become fresh within ").append(maxDuration);
+        if (!stale.isEmpty()) {
+            message.append(", still stale: ").append(stale);
+        }
+        if (lastTransientError != null) {
+            message.append("; last error while polling: ").append(lastTransientError.getMessage());
+        }
+        return message.toString();
+    }
+
+    private static void logStates(Logger logger, Map<String, ConnectorState> states) {
+        states.forEach(
+            (connectorId, state) -> logger.info(
+                "Connector '{}' syncState={} succeededAt={} fresh={}",
+                connectorId,
+                state.getSyncState(),
+                state.getSucceededAt(),
+                state.getFresh()
+            )
+        );
+    }
+
+    private void emitAssets(RunContext runContext, Map<String, Connector> connectors, Map<String, ConnectorState> states)
+        throws IllegalVariableEvaluationException {
+        for (Map.Entry<String, Connector> entry : connectors.entrySet()) {
+            String connectorId = entry.getKey();
+            Connector connector = entry.getValue();
+            // Fivetran's connector destination schema; name is the only sane fallback when it's absent.
+            String schema = connector.getSchema() != null ? connector.getSchema() : connector.getName();
+            String assetId = sanitizeAssetId(composeAssetId(connectorId, connector, schema));
+
+            Map<String, Object> metadata = new LinkedHashMap<>();
+            metadata.put("system", "fivetran");
+            metadata.put("connectorId", connectorId);
+            metadata.put("schema", schema);
+            ConnectorState state = states.get(connectorId);
+            if (state != null && state.getSyncState() != null) {
+                metadata.put("syncState", state.getSyncState());
+            }
+
+            Asset asset = Custom.builder()
+                .id(assetId)
+                .type(TABLE_ASSET_TYPE)
+                .metadata(metadata)
+                .build();
+
+            try {
+                runContext.assets().emit(new AssetEmit(List.of(), List.of(asset)));
+            } catch (UnsupportedOperationException e) {
+                // OSS edition or tests where EE assets are not available — silently skip.
+                runContext.logger().debug("Asset emission is not supported in this edition, skipping.");
+                return;
+            } catch (QueueException e) {
+                runContext.logger().warn("Unable to emit fivetran asset for connector '{}'", connectorId, e);
+            }
+        }
+    }
+
+    // groupId scopes the schema to the connector's destination so two connectors landing in the same schema
+    // (e.g. shared across groups) still get distinct asset ids; connectorId is the fallback when groupId is absent.
+    private static String composeAssetId(String connectorId, Connector connector, String schema) {
+        String prefix = connector.getGroupId() != null ? connector.getGroupId() : connectorId;
+        return schema != null ? prefix + "." + schema : connectorId;
+    }
+
+    // Fivetran ids (group_id, schema, connector id) are not guaranteed to satisfy Asset's id pattern
+    // (^[a-zA-Z0-9][a-zA-Z0-9._:-]*, size 1-150), so sanitize before handing it to the asset store.
+    // An id made only of characters stripped by the leading-alnum trim (e.g. "___") would otherwise
+    // sanitize down to "", violating Asset.id's @NotBlank/@Size(min=1); fall back to a fixed placeholder.
+    private static String sanitizeAssetId(String rawId) {
+        String sanitized = rawId
+            .replaceAll("[^a-zA-Z0-9._:-]", "_")
+            .replaceFirst("^[^a-zA-Z0-9]+", "");
+        if (sanitized.isEmpty()) {
+            sanitized = "connector";
+        }
+        return sanitized.length() > 150 ? sanitized.substring(0, 150) : sanitized;
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "Connector statuses",
+            description = "Map of connector ID to its current status, in the order the IDs were requested."
+        )
+        Map<String, ConnectorState> connectors;
+    }
+
+    @Builder
+    @Getter
+    public static class ConnectorState {
+        @Schema(
+            title = "Connector ID"
+        )
+        String id;
+
+        @Schema(
+            title = "Connector name"
+        )
+        String name;
+
+        @Schema(
+            title = "Whether the connector is paused"
+        )
+        Boolean paused;
+
+        @Schema(
+            title = "Sync frequency in minutes"
+        )
+        Integer syncFrequency;
+
+        @Schema(
+            title = "Schedule type",
+            description = "Either `auto` or `manual`."
+        )
+        String scheduleType;
+
+        @Schema(
+            title = "Timestamp of the last successful sync"
+        )
+        ZonedDateTime succeededAt;
+
+        @Schema(
+            title = "Timestamp of the last failed sync"
+        )
+        ZonedDateTime failedAt;
+
+        @Schema(
+            title = "Timestamp of the most recent sync completion",
+            description = "Whichever of `succeededAt` or `failedAt` is more recent."
+        )
+        ZonedDateTime completedDate;
+
+        @Schema(
+            title = "Whether the last sync completion was a failure",
+            description = "True only when the most recent `failedAt` is not followed by a later `succeededAt`."
+        )
+        boolean hasFailed;
+
+        @Schema(
+            title = "Current sync state",
+            description = "As reported by Fivetran, e.g. `scheduled`, `syncing`, `paused`, `rescheduled`."
+        )
+        String syncState;
+
+        @Schema(
+            title = "Current setup state",
+            description = "As reported by Fivetran, e.g. `connected`, `broken`, `incomplete`."
+        )
+        String setupState;
+
+        @Schema(
+            title = "Current schema status",
+            description = "As reported by Fivetran, e.g. `ready`, `blocked`."
+        )
+        String schemaStatus;
+
+        @Schema(
+            title = "Whether the connector's last sync is fresh",
+            description = "True when the last sync succeeded within `syncFrequency` plus `slack` of now. False when stale, or the last completion was a failure. Null when Fivetran reported no `syncFrequency` for this connector, so freshness cannot be computed."
+        )
+        Boolean fresh;
+    }
+}

--- a/src/main/java/io/kestra/plugin/fivetran/connectors/Status.java
+++ b/src/main/java/io/kestra/plugin/fivetran/connectors/Status.java
@@ -103,7 +103,7 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
         description = "Buffer added on top of each connector's `syncFrequency` when deciding whether its last sync is fresh. Default is no buffer (`PT0S`)."
     )
     @Builder.Default
-    @PluginProperty(group = "reliability")
+    @PluginProperty(group = "main")
     Property<Duration> slack = Property.ofValue(Duration.ZERO);
 
     @Schema(
@@ -111,7 +111,7 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
         description = "When true (default), poll all connectors until each one is fresh, capped by `maxDuration`. Set to false to read each connector once and report its status without gating."
     )
     @Builder.Default
-    @PluginProperty(group = "execution")
+    @PluginProperty(group = "main")
     Property<Boolean> wait = Property.ofValue(true);
 
     @Schema(
@@ -119,7 +119,7 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
         description = "Upper bound for waiting when `wait` is true. Default is 1 hour."
     )
     @Builder.Default
-    @PluginProperty(group = "execution")
+    @PluginProperty(group = "advanced")
     Property<Duration> maxDuration = Property.ofValue(Duration.ofHours(1));
 
     @Schema(
@@ -135,7 +135,7 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
         description = "When `wait` is true, a paused connector or one whose setup is not `connected` can never become fresh, so the task fails fast by default instead of polling forever. Set to true to report such connectors as not-fresh instead, letting the gate wait out `maxDuration`."
     )
     @Builder.Default
-    @PluginProperty(group = "reliability")
+    @PluginProperty(group = "advanced")
     Property<Boolean> allowFailed = Property.ofValue(false);
 
     @Override
@@ -215,9 +215,8 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
                             );
                         }
 
-                        // A connector already fresh has satisfied the gate's promise regardless of its
-                        // current paused/setup state (e.g. paused-after-sync-cost), so only fail fast when
-                        // it is NOT fresh and can never become fresh on its own.
+                        // An already-fresh connector satisfies the gate even if now paused, so only fail
+                        // fast when it is not fresh and cannot become fresh on its own.
                         if (!rAllowFailed && !Boolean.TRUE.equals(state.getFresh()) && isTerminal(connector)) {
                             throw new IllegalStateException(
                                 "Connector '" + connectorId + "' cannot become fresh: " + terminalReason(connector)
@@ -277,11 +276,9 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
     }
 
     /**
-     * Null when Fivetran reports no sync_frequency, since freshness cannot be related to a frequency that
-     * doesn't exist. Otherwise, fresh only if the last completion was a success within syncFrequency + slack
-     * of {@code now}, boundary inclusive: a success landing exactly on the threshold still counts as fresh.
-     * Package-private and parameterized on {@code now} so the boundary can be asserted deterministically in
-     * tests instead of racing the real clock.
+     * Fresh when the last completion was a success within syncFrequency + slack of {@code now}, boundary
+     * inclusive. Null when Fivetran reports no sync_frequency. Parameterized on {@code now} so tests can
+     * assert the boundary deterministically instead of racing the real clock.
      */
     static Boolean computeFresh(ZonedDateTime succeededAt, boolean hasFailed, Integer syncFrequency, Duration slack, ZonedDateTime now) {
         if (syncFrequency == null) {
@@ -383,20 +380,15 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
             : sanitizeSegment(connectorId);
     }
 
-    // Segments must be sanitized individually, before "." is added as the delimiter: a raw segment can
-    // itself contain a "." (e.g. Fivetran schema "google_sheets.destination"), so joining unsanitized
-    // segments is ambiguous, letting ("g", "a.b") and ("g.a", "b") both compose to the same id "g.a.b".
-    // Replacing "." (and anything else outside the allowed set) with "_" within each segment first means
-    // "." in the composed id can only ever be the delimiter added here.
+    // Sanitize each segment before joining so "." only ever appears as the delimiter: a raw segment can
+    // contain "." (e.g. schema "google_sheets.destination"), which would otherwise make the id ambiguous.
     private static String sanitizeSegment(String segment) {
         return segment.replaceAll("[^a-zA-Z0-9_:-]", "_");
     }
 
-    // Fivetran ids (group_id, schema, connector id) are not guaranteed to satisfy Asset's id pattern
-    // (^[a-zA-Z0-9][a-zA-Z0-9._:-]*, size 1-150). composeAssetId already restricts every segment to that
-    // character set via sanitizeSegment, so only the leading-alnum trim and size bound remain here.
-    // An id made only of characters stripped by the leading-alnum trim (e.g. "___") would otherwise
-    // sanitize down to "", violating Asset.id's @NotBlank/@Size(min=1); fall back to a fixed placeholder.
+    // Enforce the rest of Asset's id contract (^[a-zA-Z0-9]..., size 1-150) that per-segment sanitization
+    // leaves: trim leading non-alphanumerics, fall back to a placeholder if that empties the id (e.g. "___"),
+    // and cap the length.
     private static String sanitizeAssetId(String rawId) {
         String sanitized = rawId.replaceFirst("^[^a-zA-Z0-9]+", "");
         if (sanitized.isEmpty()) {

--- a/src/main/java/io/kestra/plugin/fivetran/connectors/Status.java
+++ b/src/main/java/io/kestra/plugin/fivetran/connectors/Status.java
@@ -36,8 +36,8 @@ import lombok.experimental.SuperBuilder;
 import static io.kestra.core.utils.Rethrow.throwSupplier;
 
 @SuperBuilder
-@ToString
-@EqualsAndHashCode
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @NoArgsConstructor
 @Schema(
@@ -152,6 +152,9 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
             }
         }
         Duration rSlack = runContext.render(this.slack).as(Duration.class).orElse(Duration.ZERO);
+        if (rSlack.isNegative()) {
+            throw new IllegalArgumentException("slack must not be negative, but was " + rSlack);
+        }
         boolean rWait = runContext.render(this.wait).as(Boolean.class).orElse(true);
         boolean rAllowFailed = runContext.render(this.allowFailed).as(Boolean.class).orElse(false);
 
@@ -212,7 +215,10 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
                             );
                         }
 
-                        if (!rAllowFailed && isTerminal(connector)) {
+                        // A connector already fresh has satisfied the gate's promise regardless of its
+                        // current paused/setup state (e.g. paused-after-sync-cost), so only fail fast when
+                        // it is NOT fresh and can never become fresh on its own.
+                        if (!rAllowFailed && !Boolean.TRUE.equals(state.getFresh()) && isTerminal(connector)) {
                             throw new IllegalStateException(
                                 "Connector '" + connectorId + "' cannot become fresh: " + terminalReason(connector)
                             );
@@ -372,17 +378,27 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
     // (e.g. shared across groups) still get distinct asset ids; connectorId is the fallback when groupId is absent.
     private static String composeAssetId(String connectorId, Connector connector, String schema) {
         String prefix = connector.getGroupId() != null ? connector.getGroupId() : connectorId;
-        return schema != null ? prefix + "." + schema : connectorId;
+        return schema != null
+            ? sanitizeSegment(prefix) + "." + sanitizeSegment(schema)
+            : sanitizeSegment(connectorId);
+    }
+
+    // Segments must be sanitized individually, before "." is added as the delimiter: a raw segment can
+    // itself contain a "." (e.g. Fivetran schema "google_sheets.destination"), so joining unsanitized
+    // segments is ambiguous, letting ("g", "a.b") and ("g.a", "b") both compose to the same id "g.a.b".
+    // Replacing "." (and anything else outside the allowed set) with "_" within each segment first means
+    // "." in the composed id can only ever be the delimiter added here.
+    private static String sanitizeSegment(String segment) {
+        return segment.replaceAll("[^a-zA-Z0-9_:-]", "_");
     }
 
     // Fivetran ids (group_id, schema, connector id) are not guaranteed to satisfy Asset's id pattern
-    // (^[a-zA-Z0-9][a-zA-Z0-9._:-]*, size 1-150), so sanitize before handing it to the asset store.
+    // (^[a-zA-Z0-9][a-zA-Z0-9._:-]*, size 1-150). composeAssetId already restricts every segment to that
+    // character set via sanitizeSegment, so only the leading-alnum trim and size bound remain here.
     // An id made only of characters stripped by the leading-alnum trim (e.g. "___") would otherwise
     // sanitize down to "", violating Asset.id's @NotBlank/@Size(min=1); fall back to a fixed placeholder.
     private static String sanitizeAssetId(String rawId) {
-        String sanitized = rawId
-            .replaceAll("[^a-zA-Z0-9._:-]", "_")
-            .replaceFirst("^[^a-zA-Z0-9]+", "");
+        String sanitized = rawId.replaceFirst("^[^a-zA-Z0-9]+", "");
         if (sanitized.isEmpty()) {
             sanitized = "connector";
         }

--- a/src/main/java/io/kestra/plugin/fivetran/connectors/Sync.java
+++ b/src/main/java/io/kestra/plugin/fivetran/connectors/Sync.java
@@ -34,8 +34,8 @@ import lombok.experimental.SuperBuilder;
 import static io.kestra.core.utils.Rethrow.throwSupplier;
 
 @SuperBuilder
-@ToString
-@EqualsAndHashCode
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @NoArgsConstructor
 @Schema(

--- a/src/main/java/io/kestra/plugin/fivetran/connectors/Sync.java
+++ b/src/main/java/io/kestra/plugin/fivetran/connectors/Sync.java
@@ -24,7 +24,6 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.Await;
 import io.kestra.plugin.fivetran.AbstractFivetranConnection;
 import io.kestra.plugin.fivetran.models.Connector;
-import io.kestra.plugin.fivetran.models.ConnectorResponse;
 import io.kestra.plugin.fivetran.models.SyncResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -119,7 +118,7 @@ public class Sync extends AbstractFivetranConnection implements RunnableTask<Voi
             .uri(
                 URI.create(
                     runContext.render(this.getBaseUrl()).as(String.class).orElseThrow() +
-                        "/v2/connectors/" + connectorId + "/sync"
+                        "/v2/connectors/" + encodeConnectorId(connectorId) + "/sync"
                 )
             )
             .method("POST")
@@ -203,19 +202,7 @@ public class Sync extends AbstractFivetranConnection implements RunnableTask<Voi
 
     private Connector fetchConnector(RunContext runContext) throws IllegalVariableEvaluationException, HttpClientException {
         String connectorId = runContext.render(this.connectorId).as(String.class).orElseThrow();
-
-        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
-            .uri(
-                URI.create(
-                    runContext.render(this.getBaseUrl()).as(String.class).orElseThrow() +
-                        "/v2/connectors/" + connectorId
-                )
-            )
-            .method("GET");
-
-        HttpResponse<ConnectorResponse> fetchConnector = this.request(runContext, requestBuilder, ConnectorResponse.class);
-
-        return fetchConnector.getBody().getData();
+        return this.fetchConnector(runContext, connectorId);
     }
 
 }

--- a/src/main/java/io/kestra/plugin/fivetran/models/Connector.java
+++ b/src/main/java/io/kestra/plugin/fivetran/models/Connector.java
@@ -25,6 +25,9 @@ public class Connector {
     @JsonProperty("name")
     String name;
 
+    @JsonProperty("schema")
+    String schema;
+
     @JsonProperty("paused")
     Boolean paused;
 

--- a/src/main/resources/doc/io.kestra.plugin.fivetran.md
+++ b/src/main/resources/doc/io.kestra.plugin.fivetran.md
@@ -11,3 +11,11 @@ Set `apiKey` and `apiSecret` (both required) for HTTP Basic authentication again
 `connectors.Sync` triggers a sync for a `connectorId` (required) and waits for completion by default (`wait: true`). Set `force: true` to cancel any active sync before starting a new one. By default a running sync is left as-is and the task skips. Cap wait time with `maxDuration` (default 60 minutes).
 
 While waiting, the connector status is polled every `pollFrequency` (default 5 seconds). Transient errors during polling (429, 5xx, read timeouts, and refused connections) are retried and do not fail the task, since the sync keeps running on Fivetran regardless. `maxAttempts` (default 3, total attempts including the first) and `initialRetryDelay` (default 1s) tune the per-request retry.
+
+`connectors.Status` reads the current status of one or more connectors given a `connectorIds` list (required), with a single GET per connector and no sync triggered. Output is a `connectors` map keyed by connector ID, each entry exposing sync/setup/schema state, `succeededAt`/`failedAt`, the derived `completedDate`/`hasFailed`, and a `fresh` verdict.
+
+A connector is `fresh` when its last sync succeeded within `syncFrequency` (in minutes, as reported by Fivetran) plus an optional `slack` buffer (default `PT0S`) of now. `fresh` is `null` when Fivetran reports no `syncFrequency` for the connector, since freshness cannot then be computed.
+
+By default (`wait: true`), `Status` acts as a freshness gate: it polls every `pollFrequency` (default 30 seconds) until all requested connectors are fresh, up to `maxDuration` (default 1 hour), and fails with a clear message naming the still-stale connectors if the deadline is reached. A paused connector, or one whose setup is not `connected` (`broken`, `incomplete`, bad auth), can never become fresh on its own, so the gate fails fast on it instead of polling forever; set `allowFailed: true` to instead report such a connector as not-fresh and let the gate wait out `maxDuration`. Set `wait: false` for a single read-only snapshot that never throws on stale, paused, or broken connectors.
+
+When `assets.enableAuto` is set, `Status` emits one lineage asset per connector, keyed by its Fivetran destination schema (falling back to the connector name if no schema is reported).

--- a/src/test/java/io/kestra/plugin/fivetran/AbstractFivetranConnectionTest.java
+++ b/src/test/java/io/kestra/plugin/fivetran/AbstractFivetranConnectionTest.java
@@ -1,0 +1,28 @@
+package io.kestra.plugin.fivetran;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class AbstractFivetranConnectionTest {
+
+    @Test
+    @DisplayName("Should leave a connector id without reserved characters unchanged")
+    void encodeConnectorIdLeavesSimpleIdUnchanged() {
+        assertThat(AbstractFivetranConnection.encodeConnectorId("warn_enable"), is("warn_enable"));
+    }
+
+    @Test
+    @DisplayName("Should encode a slash so it cannot inject an extra path segment")
+    void encodeConnectorIdEncodesSlash() {
+        assertThat(AbstractFivetranConnection.encodeConnectorId("a/b"), is("a%2Fb"));
+    }
+
+    @Test
+    @DisplayName("Should encode a space as %20, not the form-encoding '+', since this is a URL path segment")
+    void encodeConnectorIdEncodesSpaceAsPercent20NotPlus() {
+        assertThat(AbstractFivetranConnection.encodeConnectorId("a b"), is("a%20b"));
+    }
+}

--- a/src/test/java/io/kestra/plugin/fivetran/TestAssetManagerFactory.java
+++ b/src/test/java/io/kestra/plugin/fivetran/TestAssetManagerFactory.java
@@ -1,0 +1,57 @@
+package io.kestra.plugin.fivetran;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.kestra.core.assets.AssetManagerFactory;
+import io.kestra.core.runners.AssetEmit;
+import io.kestra.core.runners.AssetEmitter;
+
+import io.micronaut.context.annotation.Replaces;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Replaces(AssetManagerFactory.class)
+public class TestAssetManagerFactory extends AssetManagerFactory {
+    private final List<AssetEmit> allEmitted = Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public AssetEmitter of(boolean enable) {
+        return new TrackingAssetEmitter(allEmitted, enable);
+    }
+
+    /** All assets emitted across all RunContexts (for runner/integration tests). */
+    public List<AssetEmit> allEmitted() {
+        return List.copyOf(allEmitted);
+    }
+
+    public void clear() {
+        allEmitted.clear();
+    }
+
+    private static final class TrackingAssetEmitter implements AssetEmitter {
+        private final List<AssetEmit> shared;
+        private final List<AssetEmit> local = new ArrayList<>();
+        private final boolean enabled;
+
+        TrackingAssetEmitter(List<AssetEmit> shared, boolean enabled) {
+            this.shared = shared;
+            this.enabled = enabled;
+        }
+
+        @Override
+        public void emit(AssetEmit assetEmit) {
+            if (!enabled) {
+                return;
+            }
+            local.add(assetEmit);
+            shared.add(assetEmit);
+        }
+
+        @Override
+        public List<AssetEmit> emitted() {
+            return List.copyOf(local);
+        }
+    }
+}

--- a/src/test/java/io/kestra/plugin/fivetran/TestAssetManagerFactory.java
+++ b/src/test/java/io/kestra/plugin/fivetran/TestAssetManagerFactory.java
@@ -15,9 +15,13 @@ import jakarta.inject.Singleton;
 @Replaces(AssetManagerFactory.class)
 public class TestAssetManagerFactory extends AssetManagerFactory {
     private final List<AssetEmit> allEmitted = Collections.synchronizedList(new ArrayList<>());
+    private volatile boolean throwUnsupportedOperationOnEmit = false;
 
     @Override
     public AssetEmitter of(boolean enable) {
+        if (throwUnsupportedOperationOnEmit) {
+            return new ThrowingAssetEmitter();
+        }
         return new TrackingAssetEmitter(allEmitted, enable);
     }
 
@@ -26,8 +30,17 @@ public class TestAssetManagerFactory extends AssetManagerFactory {
         return List.copyOf(allEmitted);
     }
 
+    /**
+     * Makes the next emitter's {@code emit()} throw {@link UnsupportedOperationException}, mirroring the
+     * real {@link AssetManagerFactory#of(boolean)} default on OSS where the EE emitter isn't available.
+     */
+    public void throwUnsupportedOperationOnEmit(boolean throwing) {
+        this.throwUnsupportedOperationOnEmit = throwing;
+    }
+
     public void clear() {
         allEmitted.clear();
+        throwUnsupportedOperationOnEmit = false;
     }
 
     private static final class TrackingAssetEmitter implements AssetEmitter {
@@ -52,6 +65,18 @@ public class TestAssetManagerFactory extends AssetManagerFactory {
         @Override
         public List<AssetEmit> emitted() {
             return List.copyOf(local);
+        }
+    }
+
+    private static final class ThrowingAssetEmitter implements AssetEmitter {
+        @Override
+        public void emit(AssetEmit assetEmit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<AssetEmit> emitted() {
+            return List.of();
         }
     }
 }

--- a/src/test/java/io/kestra/plugin/fivetran/connectors/StatusTest.java
+++ b/src/test/java/io/kestra/plugin/fivetran/connectors/StatusTest.java
@@ -32,6 +32,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.moreThan;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -828,6 +829,108 @@ class StatusTest {
         TimeoutException thrown = assertThrows(TimeoutException.class, () -> task.run(runContext()));
         assertThat(thrown.getMessage(), containsString(connectorId));
         assertThat(thrown.getMessage(), containsString("did not become fresh"));
+    }
+
+    @Test
+    @DisplayName("Should succeed with a normal output when the asset emitter is unavailable (OSS edition)")
+    void succeedsWithNormalOutputWhenAssetEmitterThrowsUnsupportedOperationException(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "oss_asset_connector";
+        String schema = "oss_asset_connector_schema";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-10), null, false, "connected", 360, schema))
+                )
+        );
+
+        // Mirrors AssetManagerFactory#of(boolean)'s real OSS default, where emit() throws because the
+        // EE emitter isn't available.
+        assetManagerFactory.throwUnsupportedOperationOnEmit(true);
+
+        Status task = Status.builder()
+            .id("status")
+            .type(Status.class.getName())
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        Status.Output output = assertDoesNotThrow(() -> task.run(runContextFactory.of(task, Map.of())));
+
+        assertThat(output.getConnectors(), aMapWithSize(1));
+        assertThat(output.getConnectors().get(connectorId).getFresh(), is(true));
+        assertThat(assetManagerFactory.allEmitted(), is(empty()));
+    }
+
+    @Test
+    @DisplayName("Should wait for the slowest connector when multiple connectors become fresh at different times")
+    void waitsForTheSlowestConnectorAmongMultiple(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorIdA = "staggered_connector_a";
+        String connectorIdB = "staggered_connector_b";
+        String scenario = "status-staggered-multi-connector";
+
+        // A is fresh from the very first poll.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdA))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdA, isoNow(-5), null, false, "connected", 360, null))
+                )
+        );
+
+        // B stays stale for the first two poll cycles and only becomes fresh on the third.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdB))
+                .inScenario(scenario)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("STALE_ONCE_MORE")
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdB, isoNow(-600), null, false, "connected", 360, null))
+                )
+        );
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdB))
+                .inScenario(scenario)
+                .whenScenarioStateIs("STALE_ONCE_MORE")
+                .willSetStateTo("FRESH")
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdB, isoNow(-600), null, false, "connected", 360, null))
+                )
+        );
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdB))
+                .inScenario(scenario)
+                .whenScenarioStateIs("FRESH")
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdB, isoNow(-5), null, false, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorIdA, connectorIdB)))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(200)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(10)))
+            .build();
+
+        Status.Output output = task.run(runContext());
+
+        assertThat(output.getConnectors(), aMapWithSize(2));
+        assertThat(output.getConnectors().get(connectorIdA).getFresh(), is(true));
+        assertThat(output.getConnectors().get(connectorIdB).getFresh(), is(true));
+
+        // B was stale on the first two polls, so it must have been polled more than once before succeeding.
+        verify(moreThan(1), getRequestedFor(urlEqualTo("/v2/connectors/" + connectorIdB)));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/fivetran/connectors/StatusTest.java
+++ b/src/test/java/io/kestra/plugin/fivetran/connectors/StatusTest.java
@@ -1,0 +1,756 @@
+package io.kestra.plugin.fivetran.connectors;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.google.common.collect.ImmutableMap;
+
+import io.kestra.core.http.client.HttpClientResponseException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.assets.Asset;
+import io.kestra.core.models.assets.AssetsDeclaration;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.AssetEmit;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.plugin.fivetran.TestAssetManagerFactory;
+
+import jakarta.inject.Inject;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+@WireMockTest
+class StatusTest {
+    private static final String SUCCEEDED_CONNECTOR_ID = "succeeded_connector";
+    private static final String STALE_FAILED_CONNECTOR_ID = "stale_failed_connector";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private TestAssetManagerFactory assetManagerFactory;
+
+    @BeforeEach
+    void setUp() {
+        assetManagerFactory.clear();
+    }
+
+    @Test
+    @DisplayName("Should read the status of several connectors without triggering a sync")
+    void readsStatusOfMultipleConnectorsWithoutSyncing(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        // succeeded_at more recent than failed_at: the last completion is a success.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + SUCCEEDED_CONNECTOR_ID))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(SUCCEEDED_CONNECTOR_ID, "2026-07-27T13:13:08.389Z", "2026-04-28T03:06:48.382Z"))
+                )
+        );
+
+        // failed_at more recent than succeeded_at: the last completion is a genuine failure.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + STALE_FAILED_CONNECTOR_ID))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(STALE_FAILED_CONNECTOR_ID, "2026-01-01T00:00:00.000Z", "2026-07-27T13:13:08.389Z"))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(SUCCEEDED_CONNECTOR_ID, STALE_FAILED_CONNECTOR_ID)))
+            .wait(Property.ofValue(false))
+            .build();
+
+        Status.Output output = task.run(runContext());
+
+        assertThat(output.getConnectors(), aMapWithSize(2));
+
+        Status.ConnectorState succeeded = output.getConnectors().get(SUCCEEDED_CONNECTOR_ID);
+        assertThat(succeeded.getId(), is(SUCCEEDED_CONNECTOR_ID));
+        assertThat(succeeded.getName(), is(SUCCEEDED_CONNECTOR_ID));
+        assertThat(succeeded.getPaused(), is(false));
+        assertThat(succeeded.getSyncFrequency(), is(360));
+        assertThat(succeeded.getScheduleType(), is("auto"));
+        assertThat(succeeded.getSyncState(), is("scheduled"));
+        assertThat(succeeded.getSetupState(), is("connected"));
+        assertThat(succeeded.getSchemaStatus(), is("ready"));
+        assertThat(succeeded.getSucceededAt(), is(ZonedDateTime.parse("2026-07-27T13:13:08.389Z")));
+        assertThat(succeeded.getFailedAt(), is(ZonedDateTime.parse("2026-04-28T03:06:48.382Z")));
+        assertThat(succeeded.getCompletedDate(), is(ZonedDateTime.parse("2026-07-27T13:13:08.389Z")));
+        assertThat(succeeded.isHasFailed(), is(false));
+
+        Status.ConnectorState staleFailed = output.getConnectors().get(STALE_FAILED_CONNECTOR_ID);
+        assertThat(staleFailed.getSucceededAt(), is(ZonedDateTime.parse("2026-01-01T00:00:00.000Z")));
+        assertThat(staleFailed.getFailedAt(), is(ZonedDateTime.parse("2026-07-27T13:13:08.389Z")));
+        assertThat(staleFailed.getCompletedDate(), is(ZonedDateTime.parse("2026-07-27T13:13:08.389Z")));
+        assertThat(staleFailed.isHasFailed(), is(true));
+        // failedAt was the last completion, so it can never be fresh regardless of the clock.
+        assertThat(staleFailed.getFresh(), is(false));
+
+        verify(exactly(1), getRequestedFor(urlEqualTo("/v2/connectors/" + SUCCEEDED_CONNECTOR_ID)));
+        verify(exactly(1), getRequestedFor(urlEqualTo("/v2/connectors/" + STALE_FAILED_CONNECTOR_ID)));
+        verify(exactly(0), postRequestedFor(urlMatching(".*/sync")));
+    }
+
+    @Test
+    @DisplayName("Should mark a connector fresh only when its last success is within syncFrequency plus slack")
+    void computesFreshnessFromSucceededAtAndSyncFrequency(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String freshConnectorId = "fresh_connector";
+        String staleConnectorId = "stale_connector";
+
+        // 10 minutes ago, well within the 360-minute sync_frequency.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + freshConnectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(freshConnectorId, isoNow(-10), null, false, "connected", 360, null))
+                )
+        );
+
+        // 10 hours ago, well beyond the 360-minute sync_frequency.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + staleConnectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(staleConnectorId, isoNow(-600), null, false, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(freshConnectorId, staleConnectorId)))
+            .wait(Property.ofValue(false))
+            .build();
+
+        Status.Output output = task.run(runContext());
+
+        assertThat(output.getConnectors().get(freshConnectorId).getFresh(), is(true));
+        assertThat(output.getConnectors().get(staleConnectorId).getFresh(), is(false));
+    }
+
+    @Test
+    @DisplayName("Should let slack widen the freshness window beyond syncFrequency")
+    void slackWidensTheFreshnessWindow(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "slack_connector";
+
+        // 400 minutes ago: stale against a 360-minute sync_frequency alone, fresh once a 1-hour slack is added.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-400), null, false, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .slack(Property.ofValue(Duration.ofHours(1)))
+            .build();
+
+        Status.Output output = task.run(runContext());
+
+        assertThat(output.getConnectors().get(connectorId).getFresh(), is(true));
+    }
+
+    @Test
+    @DisplayName("Should report fresh as null without throwing when wait is false and sync_frequency is missing")
+    void reportsNullFreshWhenSyncFrequencyMissingAndNotWaiting(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "no_frequency_connector";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, null, null, false, "connected", null, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .build();
+
+        Status.Output output = task.run(runContext());
+
+        assertThat(output.getConnectors().get(connectorId).getFresh(), is(nullValue()));
+    }
+
+    @Test
+    @DisplayName("Should fail fast instead of polling forever when sync_frequency is missing while waiting")
+    void failsFastWhenSyncFrequencyMissingInWaitMode(WireMockRuntimeInfo wmRuntimeInfo) {
+        String connectorId = "no_frequency_connector_waiting";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, null, null, false, "connected", null, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(100)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .build();
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString(connectorId));
+        assertThat(thrown.getMessage(), containsString("sync_frequency"));
+    }
+
+    @Test
+    @DisplayName("Should fail fast on a paused connector when waiting for freshness")
+    void failsFastOnPausedConnectorInWaitMode(WireMockRuntimeInfo wmRuntimeInfo) {
+        String connectorId = "paused_connector";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, null, null, true, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(100)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .build();
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString(connectorId));
+        assertThat(thrown.getMessage(), containsString("cannot become fresh"));
+        assertThat(thrown.getMessage(), containsString("paused=true"));
+    }
+
+    @Test
+    @DisplayName("Should fail fast on a connector whose setup is not connected when waiting for freshness")
+    void failsFastOnNonConnectedSetupStateInWaitMode(WireMockRuntimeInfo wmRuntimeInfo) {
+        String connectorId = "broken_connector";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, null, null, false, "broken", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(100)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .build();
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString(connectorId));
+        assertThat(thrown.getMessage(), containsString("setupState=broken"));
+    }
+
+    @Test
+    @DisplayName("Should poll until the connector becomes fresh and then return success")
+    void pollsUntilConnectorBecomesFreshThenSucceeds(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "poll_until_fresh_connector";
+        String scenario = "status-poll-until-fresh";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .inScenario(scenario)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("FRESH")
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-600), null, false, "connected", 360, null))
+                )
+        );
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .inScenario(scenario)
+                .whenScenarioStateIs("FRESH")
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-5), null, false, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .pollFrequency(Property.ofValue(Duration.ofSeconds(1)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(10)))
+            .build();
+
+        Status.Output output = task.run(runContext());
+
+        assertThat(output.getConnectors().get(connectorId).getFresh(), is(true));
+    }
+
+    @Test
+    @DisplayName("Should throw naming the stale connector when it never becomes fresh before maxDuration")
+    void throwsTimeoutNamingStaleConnectorWhenDeadlineIsReached(WireMockRuntimeInfo wmRuntimeInfo) {
+        String connectorId = "always_stale_connector";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-600), null, false, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(200)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(1)))
+            .build();
+
+        TimeoutException thrown = assertThrows(TimeoutException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString(connectorId));
+        assertThat(thrown.getMessage(), containsString("did not become fresh"));
+    }
+
+    @Test
+    @DisplayName("Should emit one asset per connector with a groupId-scoped id when assets.enableAuto is true")
+    void emitsOneAssetPerConnectorWhenAssetsEnabled(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "asset_connector";
+        String schema = "asset_connector_dest_schema";
+        // connectorBody's fixture hardcodes group_id to "some_group", so the composed id is "some_group.<schema>".
+        String expectedAssetId = "some_group." + schema;
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-10), null, false, "connected", 360, schema))
+                )
+        );
+
+        Status task = Status.builder()
+            .id("status")
+            .type(Status.class.getName())
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        Status.Output output = task.run(runContextFactory.of(task, Map.of()));
+
+        assertThat(output.getConnectors().get(connectorId).getFresh(), is(true));
+
+        List<AssetEmit> emitted = assetManagerFactory.allEmitted();
+        assertThat(emitted, hasSize(1));
+
+        Asset asset = emitted.get(0).outputs().get(0);
+        assertThat(asset.getId(), is(expectedAssetId));
+        assertThat(asset.getType(), is("io.kestra.plugin.ee.assets.Table"));
+        assertThat(asset.getMetadata().get("connectorId"), is(connectorId));
+        assertThat(asset.getMetadata().get("schema"), is(schema));
+    }
+
+    @Test
+    @DisplayName("Should emit no asset when assets.enableAuto is unset (default)")
+    void emitsNoAssetWhenAssetsNotEnabled(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "asset_disabled_connector";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-10), null, false, "connected", 360, "some_schema"))
+                )
+        );
+
+        Status task = Status.builder()
+            .id("status")
+            .type(Status.class.getName())
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .build();
+
+        task.run(runContextFactory.of(task, Map.of()));
+
+        assertThat(assetManagerFactory.allEmitted(), is(empty()));
+    }
+
+    @Test
+    @DisplayName("Should emit distinct asset ids for two connectors sharing the same schema")
+    void emitsDistinctAssetIdsForConnectorsSharingSchema(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorIdA = "collision_connector_a";
+        String connectorIdB = "collision_connector_b";
+        String sharedSchema = "shared_schema";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdA))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdA, isoNow(-10), null, false, "connected", 360, sharedSchema, "group_alpha"))
+                )
+        );
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdB))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdB, isoNow(-10), null, false, "connected", 360, sharedSchema, "group_beta"))
+                )
+        );
+
+        Status task = Status.builder()
+            .id("status")
+            .type(Status.class.getName())
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorIdA, connectorIdB)))
+            .wait(Property.ofValue(false))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        task.run(runContextFactory.of(task, Map.of()));
+
+        List<AssetEmit> emitted = assetManagerFactory.allEmitted();
+        assertThat(emitted, hasSize(2));
+
+        String idA = emitted.get(0).outputs().get(0).getId();
+        String idB = emitted.get(1).outputs().get(0).getId();
+        assertThat(idA, is("group_alpha." + sharedSchema));
+        assertThat(idB, is("group_beta." + sharedSchema));
+        assertThat(idA, is(not(idB)));
+    }
+
+    @Test
+    @DisplayName("Should fall back to a non-empty placeholder asset id when groupId and schema sanitize down to nothing")
+    void fallsBackToNonEmptyAssetIdWhenComposedIdSanitizesToEmpty(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "underscore_connector";
+
+        // groupId="_" and schema="_" compose to "_._", which is entirely non-alphanumeric and would
+        // otherwise sanitize down to "", violating Asset.id's @NotBlank/@Size(min=1) constraint.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-10), null, false, "connected", 360, "_", "_"))
+                )
+        );
+
+        Status task = Status.builder()
+            .id("status")
+            .type(Status.class.getName())
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        task.run(runContextFactory.of(task, Map.of()));
+
+        List<AssetEmit> emitted = assetManagerFactory.allEmitted();
+        assertThat(emitted, hasSize(1));
+        assertThat(emitted.get(0).outputs().get(0).getId(), is("connector"));
+    }
+
+    @Test
+    @DisplayName("Should treat a connector whose last success is just inside the freshness threshold as fresh")
+    void treatsJustInsideThresholdAsFreshInclusiveBoundary(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "boundary_connector";
+        int syncFrequencyMinutes = 5;
+        Duration slack = Duration.ofSeconds(30);
+
+        // The freshness threshold is `now - (syncFrequency + slack)`, evaluated at task run time. Exact
+        // equality can't be asserted from a black-box test since "now" is not injectable, so succeededAt is
+        // pinned 1 second newer than the threshold computed here, right before the stub is set up. Task
+        // execution (a couple of WireMock round trips) always finishes well under that 1s margin, so the
+        // connector remains inside the window at evaluation time. Under the old strict `isAfter` check this
+        // margin would occasionally get eaten by test-execution jitter and flip the result to stale; the
+        // inclusive `!isBefore` check keeps it deterministically fresh.
+        ZonedDateTime threshold = ZonedDateTime.now().minusMinutes(syncFrequencyMinutes).minus(slack);
+        String succeededAt = threshold.plusSeconds(1).toInstant().toString();
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, succeededAt, null, false, "connected", syncFrequencyMinutes, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .slack(Property.ofValue(slack))
+            .build();
+
+        Status.Output output = task.run(runContext());
+
+        assertThat(output.getConnectors().get(connectorId).getFresh(), is(true));
+    }
+
+    @Test
+    @DisplayName("Should treat succeededAt exactly at the syncFrequency+slack threshold as fresh, and one nanosecond later as stale")
+    void computeFreshIsInclusiveOfTheExactBoundary() {
+        ZonedDateTime succeededAt = ZonedDateTime.parse("2026-01-01T00:00:00Z");
+        int syncFrequencyMinutes = 60;
+        Duration slack = Duration.ofMinutes(5);
+        // The threshold is `now - syncFrequency - slack`; equivalently, succeededAt is fresh as long as
+        // `now` has not yet passed `succeededAt + syncFrequency + slack`.
+        ZonedDateTime boundaryNow = succeededAt.plusMinutes(syncFrequencyMinutes).plus(slack);
+
+        assertThat(
+            Status.computeFresh(succeededAt, false, syncFrequencyMinutes, slack, boundaryNow),
+            is(true)
+        );
+        assertThat(
+            Status.computeFresh(succeededAt, false, syncFrequencyMinutes, slack, boundaryNow.plusNanos(1)),
+            is(false)
+        );
+        assertThat(
+            Status.computeFresh(succeededAt, false, null, slack, boundaryNow),
+            is(nullValue())
+        );
+        assertThat(
+            Status.computeFresh(succeededAt, true, syncFrequencyMinutes, slack, succeededAt),
+            is(false)
+        );
+    }
+
+    @Test
+    @DisplayName("Should fail clearly and without retrying when a connector is not found")
+    void failsClearlyOn404WithoutRetrying(WireMockRuntimeInfo wmRuntimeInfo) {
+        String connectorId = "missing_connector";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(aResponse().withStatus(404))
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .build();
+
+        assertThrows(HttpClientResponseException.class, () -> task.run(runContext()));
+
+        // 404 is not a retriable transient error, so it must fail on the very first call.
+        verify(exactly(1), getRequestedFor(urlEqualTo("/v2/connectors/" + connectorId)));
+    }
+
+    @Test
+    @DisplayName("Should fail clearly when connectorIds is empty instead of vacuously succeeding")
+    void failsWhenConnectorIdsIsEmpty(WireMockRuntimeInfo wmRuntimeInfo) {
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of()))
+            .build();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString("connectorIds must not be empty"));
+    }
+
+    @Test
+    @DisplayName("Should fail clearly naming the index when connectorIds contains a blank element")
+    void failsWhenConnectorIdsContainsBlankElement(WireMockRuntimeInfo wmRuntimeInfo) {
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of("valid_connector", "   ")))
+            .wait(Property.ofValue(false))
+            .build();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString("connectorIds[1]"));
+        assertThat(thrown.getMessage(), containsString("null or blank"));
+
+        verify(exactly(0), getRequestedFor(urlMatching("/v2/connectors/.*")));
+    }
+
+    @Test
+    @DisplayName("Should fail clearly naming the index when connectorIds contains a null element")
+    void failsWhenConnectorIdsContainsNullElement(WireMockRuntimeInfo wmRuntimeInfo) {
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(Arrays.asList("valid_connector", null)))
+            .wait(Property.ofValue(false))
+            .build();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString("connectorIds[1]"));
+        assertThat(thrown.getMessage(), containsString("null or blank"));
+
+        verify(exactly(0), getRequestedFor(urlMatching("/v2/connectors/.*")));
+    }
+
+    @Test
+    @DisplayName("Should reject pollFrequency greater than maxDuration before polling")
+    void failsWhenPollFrequencyExceedsMaxDuration(WireMockRuntimeInfo wmRuntimeInfo) {
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of("any_connector")))
+            .pollFrequency(Property.ofValue(Duration.ofMinutes(10)))
+            .maxDuration(Property.ofValue(Duration.ofMinutes(2)))
+            .build();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString("pollFrequency"));
+        assertThat(thrown.getMessage(), containsString("maxDuration"));
+    }
+
+    private RunContext runContext() {
+        return runContextFactory.of(ImmutableMap.of());
+    }
+
+    private static String isoNow(long minutesOffset) {
+        return ZonedDateTime.now().plusMinutes(minutesOffset).toInstant().toString();
+    }
+
+    private static String connectorBody(String connectorId, String succeededAt, String failedAt) {
+        return connectorBody(connectorId, succeededAt, failedAt, false, "connected", 360, null);
+    }
+
+    private static String connectorBody(
+        String connectorId,
+        String succeededAt,
+        String failedAt,
+        boolean paused,
+        String setupState,
+        Integer syncFrequency,
+        String schema) {
+        return connectorBody(connectorId, succeededAt, failedAt, paused, setupState, syncFrequency, schema, "some_group");
+    }
+
+    private static String connectorBody(
+        String connectorId,
+        String succeededAt,
+        String failedAt,
+        boolean paused,
+        String setupState,
+        Integer syncFrequency,
+        String schema,
+        String groupId) {
+        return """
+            {
+              "code": "Success",
+              "data": {
+                "id": "%s",
+                "name": "%s",
+                %s
+                "paused": %s,
+                "version": 1,
+                "status": {
+                  "setup_state": "%s",
+                  "sync_state": "scheduled",
+                  "update_state": "on_schedule",
+                  "is_historical_sync": false,
+                  "schema_status": "ready",
+                  "tasks": [],
+                  "warnings": []
+                },
+                "daily_sync_time": "14:00",
+                "succeeded_at": %s,
+                "connector_type_id": "postgres",
+                "sync_frequency": %s,
+                "pause_after_trial": false,
+                "group_id": "%s",
+                "connected_by": "some_user",
+                "created_at": "2025-01-01T00:00:00.000Z",
+                "failed_at": %s,
+                "schedule_type": "auto"
+              }
+            }
+            """.formatted(
+            connectorId,
+            connectorId,
+            schemaField(schema),
+            paused,
+            setupState,
+            jsonValue(succeededAt),
+            syncFrequency == null ? "null" : syncFrequency.toString(),
+            groupId,
+            jsonValue(failedAt)
+        );
+    }
+
+    private static String schemaField(String schema) {
+        return schema == null ? "" : "\"schema\": \"" + schema + "\",";
+    }
+
+    private static String jsonValue(String value) {
+        return value == null ? "null" : "\"" + value + "\"";
+    }
+}

--- a/src/test/java/io/kestra/plugin/fivetran/connectors/StatusTest.java
+++ b/src/test/java/io/kestra/plugin/fivetran/connectors/StatusTest.java
@@ -45,6 +45,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
@@ -272,6 +273,38 @@ class StatusTest {
     }
 
     @Test
+    @DisplayName("Should succeed in wait mode when a connector is already fresh even though it is now paused")
+    void succeedsOnAlreadyFreshPausedConnectorInWaitMode(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "fresh_then_paused_connector";
+
+        // Fivetran commonly pauses a connector right after it syncs to control cost; it is still fresh,
+        // so the fail-fast gate must not fire on it.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-10), null, true, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(true))
+            .allowFailed(Property.ofValue(false))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(100)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(5)))
+            .build();
+
+        Status.Output output = task.run(runContext());
+
+        assertThat(output.getConnectors().get(connectorId).getFresh(), is(true));
+        assertThat(output.getConnectors().get(connectorId).getPaused(), is(true));
+    }
+
+    @Test
     @DisplayName("Should fail fast on a connector whose setup is not connected when waiting for freshness")
     void failsFastOnNonConnectedSetupStateInWaitMode(WireMockRuntimeInfo wmRuntimeInfo) {
         String connectorId = "broken_connector";
@@ -481,6 +514,86 @@ class StatusTest {
     }
 
     @Test
+    @DisplayName("Should sanitize a dot inside a schema so it is never mistaken for the group/schema delimiter")
+    void sanitizesDotInsideSchemaSoItCannotCollideWithDelimiter(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "dotted_schema_connector";
+        // Fivetran can report a schema containing a dot, e.g. "google_sheets.destination".
+        String schema = "google_sheets.destination";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-10), null, false, "connected", 360, schema))
+                )
+        );
+
+        Status task = Status.builder()
+            .id("status")
+            .type(Status.class.getName())
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .wait(Property.ofValue(false))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        task.run(runContextFactory.of(task, Map.of()));
+
+        List<AssetEmit> emitted = assetManagerFactory.allEmitted();
+        assertThat(emitted, hasSize(1));
+        // connectorBody's fixture hardcodes group_id to "some_group"; the schema's dot is replaced with "_".
+        assertThat(emitted.get(0).outputs().get(0).getId(), is("some_group.google_sheets_destination"));
+    }
+
+    @Test
+    @DisplayName("Should compose distinct asset ids for a dotted groupId/schema pair that would otherwise collide")
+    void composesDistinctAssetIdsForDottedSegmentsThatWouldOtherwiseCollide(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorIdA = "collision_dot_connector_a";
+        String connectorIdB = "collision_dot_connector_b";
+
+        // Without per-segment sanitization, groupId="g"/schema="a.b" and groupId="g.a"/schema="b" would both
+        // naively join to "g.a.b". Sanitizing each segment before joining keeps their composed ids distinct.
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdA))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdA, isoNow(-10), null, false, "connected", 360, "a.b", "g"))
+                )
+        );
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdB))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdB, isoNow(-10), null, false, "connected", 360, "b", "g.a"))
+                )
+        );
+
+        Status task = Status.builder()
+            .id("status")
+            .type(Status.class.getName())
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorIdA, connectorIdB)))
+            .wait(Property.ofValue(false))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        task.run(runContextFactory.of(task, Map.of()));
+
+        List<AssetEmit> emitted = assetManagerFactory.allEmitted();
+        assertThat(emitted, hasSize(2));
+
+        String idA = emitted.get(0).outputs().get(0).getId();
+        String idB = emitted.get(1).outputs().get(0).getId();
+        assertThat(idA, is("g.a_b"));
+        assertThat(idB, is("g_a.b"));
+        assertThat(idA, is(not(idB)));
+    }
+
+    @Test
     @DisplayName("Should fall back to a non-empty placeholder asset id when groupId and schema sanitize down to nothing")
     void fallsBackToNonEmptyAssetIdWhenComposedIdSanitizesToEmpty(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         String connectorId = "underscore_connector";
@@ -669,6 +782,93 @@ class StatusTest {
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> task.run(runContext()));
         assertThat(thrown.getMessage(), containsString("pollFrequency"));
         assertThat(thrown.getMessage(), containsString("maxDuration"));
+    }
+
+    @Test
+    @DisplayName("Should reject a negative slack before making any HTTP call")
+    void failsWhenSlackIsNegative(WireMockRuntimeInfo wmRuntimeInfo) {
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of("any_connector")))
+            .wait(Property.ofValue(false))
+            .slack(Property.ofValue(Duration.ofMinutes(-5)))
+            .build();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString("slack must not be negative"));
+
+        verify(exactly(0), getRequestedFor(urlMatching("/v2/connectors/.*")));
+    }
+
+    @Test
+    @DisplayName("Should not fail fast but time out when allowFailed is true and a stale connector is paused")
+    void allowFailedLetsStalePausedConnectorTimeOutInsteadOfFailingFast(WireMockRuntimeInfo wmRuntimeInfo) {
+        String connectorId = "allow_failed_stale_paused_connector";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, null, null, true, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            .allowFailed(Property.ofValue(true))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(100)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(1)))
+            .build();
+
+        TimeoutException thrown = assertThrows(TimeoutException.class, () -> task.run(runContext()));
+        assertThat(thrown.getMessage(), containsString(connectorId));
+        assertThat(thrown.getMessage(), containsString("did not become fresh"));
+    }
+
+    @Test
+    @DisplayName("Should recover from a transient error mid-poll and eventually succeed")
+    void recoversFromTransientErrorMidPollInWaitMode(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorId = "transient_error_connector";
+        String scenario = "status-transient-error-recovery";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .inScenario(scenario)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("RECOVERED")
+                .willReturn(aResponse().withStatus(503))
+        );
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorId))
+                .inScenario(scenario)
+                .whenScenarioStateIs("RECOVERED")
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorId, isoNow(-5), null, false, "connected", 360, null))
+                )
+        );
+
+        Status task = Status.builder()
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorId)))
+            // A single attempt so the 503 bubbles up to the poll loop's own transient-error handling
+            // instead of being absorbed by the low-level request() retry.
+            .maxAttempts(Property.ofValue(1))
+            .pollFrequency(Property.ofValue(Duration.ofMillis(200)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(10)))
+            .build();
+
+        Status.Output output = assertDoesNotThrow(() -> task.run(runContext()));
+
+        assertThat(output.getConnectors().get(connectorId).getFresh(), is(true));
     }
 
     private RunContext runContext() {


### PR DESCRIPTION
Closes #95.

## What

Adds `connectors.Status`: takes a list of connector IDs, reports whether each is fresh, and never triggers a sync. `Sync` is unchanged (only a shared `fetchConnector` helper was extracted).

## Behavior

- **Input**: `connectorIds` (list). Reads each via `GET /v2/connectors/{id}`. No POST.
- **Freshness**: `fresh = succeeded_at >= now - (sync_frequency + slack)`, per connector. `slack` is a configurable buffer.
- **Gate** (`wait: true`, default): polls until all connectors are fresh. Fails fast on paused/broken/bad-auth that are not already fresh. Keeps polling on stale. On `maxDuration`, fails with a message naming the still-stale connectors (decoupled from the pod timeout).
- **Snapshot** (`wait: false`): single read, returns state, never throws on stale/paused.
- **Output**: `Map<connectorId, ConnectorState>` with `succeededAt`, `failedAt`, `completedDate`, `hasFailed`, `fresh`, `paused`, `syncState`, `setupState`, `schemaStatus`, `syncFrequency`, `scheduleType`.
- **Lineage**: emits one asset per connector destination schema when `assets.enableAuto: true` (EE only, no-ops on OSS).

## Notes

- Reuses existing `Connector.completedDate()` / `hasFailed()` (handles the "Fivetran never clears failed_at" quirk) and `Sync`'s `Await` polling.
- `connectorId` is path-encoded on both GET and POST. Secrets excluded from `toString`. Negative `slack` and null/blank/empty `connectorIds` rejected.

## Testing

- 51 tests (WireMock), including inclusive freshness boundary, fail-fast, already-fresh-but-paused, poll-until-fresh transition, deadline timeout, transient-error recovery, asset emission + gating, and no-POST verification.
- Verified live against a real Fivetran account on Kestra EE: multi-connector read, freshness, fail-fast, and asset emission.