### PR TITLE
fix(connectors): derive Status asset schema from destination_schema.name

### DIFF
--- a/src/main/java/io/kestra/plugin/fivetran/connectors/Status.java
+++ b/src/main/java/io/kestra/plugin/fivetran/connectors/Status.java
@@ -340,8 +340,7 @@ public class Status extends AbstractFivetranConnection implements RunnableTask<S
         for (Map.Entry<String, Connector> entry : connectors.entrySet()) {
             String connectorId = entry.getKey();
             Connector connector = entry.getValue();
-            // Fivetran's connector destination schema; name is the only sane fallback when it's absent.
-            String schema = connector.getSchema() != null ? connector.getSchema() : connector.getName();
+            String schema = connector.destinationSchemaName();
             String assetId = sanitizeAssetId(composeAssetId(connectorId, connector, schema));
 
             Map<String, Object> metadata = new LinkedHashMap<>();

--- a/src/main/java/io/kestra/plugin/fivetran/models/Connector.java
+++ b/src/main/java/io/kestra/plugin/fivetran/models/Connector.java
@@ -28,6 +28,9 @@ public class Connector {
     @JsonProperty("schema")
     String schema;
 
+    @JsonProperty("destination_schema")
+    DestinationSchema destinationSchema;
+
     @JsonProperty("paused")
     Boolean paused;
 
@@ -97,5 +100,17 @@ public class Connector {
     public boolean hasFailed() {
         return this.getFailedAt() != null &&
             (this.getSucceededAt() == null || !this.getSucceededAt().isAfter(this.getFailedAt()));
+    }
+
+    // Prefer the structured, stable destination_schema.name. Fall back to the legacy top-level `schema`
+    // (older API), and only then to the editable display name as a last resort.
+    public String destinationSchemaName() {
+        if (this.destinationSchema != null && this.destinationSchema.getName() != null) {
+            return this.destinationSchema.getName();
+        }
+        if (this.schema != null) {
+            return this.schema;
+        }
+        return this.name;
     }
 }

--- a/src/main/java/io/kestra/plugin/fivetran/models/DestinationSchema.java
+++ b/src/main/java/io/kestra/plugin/fivetran/models/DestinationSchema.java
@@ -1,0 +1,21 @@
+package io.kestra.plugin.fivetran.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Value;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Jacksonized
+@SuperBuilder
+public class DestinationSchema {
+    @JsonProperty("name")
+    String name;
+
+    @JsonProperty("table")
+    String table;
+
+    @JsonProperty("table_group_name")
+    String tableGroupName;
+}

--- a/src/test/java/io/kestra/plugin/fivetran/connectors/StatusTest.java
+++ b/src/test/java/io/kestra/plugin/fivetran/connectors/StatusTest.java
@@ -549,6 +549,57 @@ class StatusTest {
     }
 
     @Test
+    @DisplayName("Should derive the asset id's schema segment from destination_schema.name, independent of the editable connector name")
+    void assetIdSchemaSegmentIsDerivedFromDestinationSchemaNameNotConnectorName(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String connectorIdA = "renamed_connector_a";
+        String connectorIdB = "renamed_connector_b";
+        // The API's `name` for a connector landing in the "google_sheets" destination schema is
+        // conventionally "<schema>.<table>", which is exactly the value the old, buggy fallback used.
+        String editableNameA = "google_sheets.destination";
+        String editableNameB = "a_totally_different_display_name";
+        String stableDestinationSchemaName = "google_sheets";
+
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdA))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdA, editableNameA, isoNow(-10), null, false, "connected", 360, stableDestinationSchemaName, "some_group"))
+                )
+        );
+        stubFor(
+            get(urlEqualTo("/v2/connectors/" + connectorIdB))
+                .willReturn(
+                    aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody(connectorBody(connectorIdB, editableNameB, isoNow(-10), null, false, "connected", 360, stableDestinationSchemaName, "some_group"))
+                )
+        );
+
+        Status task = Status.builder()
+            .id("status")
+            .type(Status.class.getName())
+            .apiKey(Property.ofValue("dummy-api-key"))
+            .apiSecret(Property.ofValue("dummy-api-secret"))
+            .baseUrl(Property.ofValue(wmRuntimeInfo.getHttpBaseUrl()))
+            .connectorIds(Property.ofValue(List.of(connectorIdA, connectorIdB)))
+            .wait(Property.ofValue(false))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        task.run(runContextFactory.of(task, Map.of()));
+
+        List<AssetEmit> emitted = assetManagerFactory.allEmitted();
+        assertThat(emitted, hasSize(2));
+
+        String idA = emitted.get(0).outputs().get(0).getId();
+        String idB = emitted.get(1).outputs().get(0).getId();
+        // Same destination_schema.name and groupId across both connectors, despite completely different
+        // editable names, must yield the same, name-independent asset id.
+        assertThat(idA, is("some_group.google_sheets"));
+        assertThat(idB, is("some_group.google_sheets"));
+        assertThat(idA, is(idB));
+    }
+
+    @Test
     @DisplayName("Should compose distinct asset ids for a dotted groupId/schema pair that would otherwise collide")
     void composesDistinctAssetIdsForDottedSegmentsThatWouldOtherwiseCollide(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         String connectorIdA = "collision_dot_connector_a";
@@ -1006,12 +1057,28 @@ class StatusTest {
         Integer syncFrequency,
         String schema,
         String groupId) {
+        return connectorBody(connectorId, connectorId, succeededAt, failedAt, paused, setupState, syncFrequency, schema, groupId);
+    }
+
+    // The real Fivetran v2 API always returns a null top-level `schema` and carries the stable schema name
+    // under `destination_schema.name` instead; `name` is the separate, user-editable display name.
+    private static String connectorBody(
+        String connectorId,
+        String name,
+        String succeededAt,
+        String failedAt,
+        boolean paused,
+        String setupState,
+        Integer syncFrequency,
+        String schema,
+        String groupId) {
         return """
             {
               "code": "Success",
               "data": {
                 "id": "%s",
                 "name": "%s",
+                "schema": null,
                 %s
                 "paused": %s,
                 "version": 1,
@@ -1038,8 +1105,8 @@ class StatusTest {
             }
             """.formatted(
             connectorId,
-            connectorId,
-            schemaField(schema),
+            name,
+            destinationSchemaField(schema),
             paused,
             setupState,
             jsonValue(succeededAt),
@@ -1049,8 +1116,10 @@ class StatusTest {
         );
     }
 
-    private static String schemaField(String schema) {
-        return schema == null ? "" : "\"schema\": \"" + schema + "\",";
+    private static String destinationSchemaField(String schema) {
+        return schema == null
+            ? ""
+            : "\"destination_schema\": {\"name\": \"" + schema + "\", \"table\": \"destination\", \"table_group_name\": \"destination\"},";
     }
 
     private static String jsonValue(String value) {

--- a/src/test/java/io/kestra/plugin/fivetran/models/ConnectorTest.java
+++ b/src/test/java/io/kestra/plugin/fivetran/models/ConnectorTest.java
@@ -54,4 +54,39 @@ class ConnectorTest {
 
         assertThat(connector.hasFailed(), is(true));
     }
+
+    // The v2 GET /connectors/{id} endpoint always returns a null top-level `schema`, so destination_schema.name
+    // is the only stable source; falling back to the editable `name` would silently break lineage on rename.
+    @Test
+    @DisplayName("Should prefer destination_schema.name when present")
+    void destinationSchemaNamePrefersStructuredDestinationSchema() {
+        Connector connector = Connector.builder()
+            .name("google_sheets.destination")
+            .schema("legacy_schema")
+            .destinationSchema(DestinationSchema.builder().name("google_sheets").build())
+            .build();
+
+        assertThat(connector.destinationSchemaName(), is("google_sheets"));
+    }
+
+    @Test
+    @DisplayName("Should fall back to the legacy top-level schema when destination_schema is absent")
+    void destinationSchemaNameFallsBackToLegacySchema() {
+        Connector connector = Connector.builder()
+            .name("google_sheets.destination")
+            .schema("legacy_schema")
+            .build();
+
+        assertThat(connector.destinationSchemaName(), is("legacy_schema"));
+    }
+
+    @Test
+    @DisplayName("Should fall back to the editable name as a last resort when both destination_schema and schema are absent")
+    void destinationSchemaNameFallsBackToNameAsLastResort() {
+        Connector connector = Connector.builder()
+            .name("google_sheets.destination")
+            .build();
+
+        assertThat(connector.destinationSchemaName(), is("google_sheets.destination"));
+    }
 }


### PR DESCRIPTION
Fixes #98 (bug 1).

On `/v2/connectors/{id}` the top-level `schema` is null; the destination schema lives in `destination_schema.name`. `Status` was falling back to the editable connector `name`, so renaming a connector silently changed its asset id and broke lineage identity.

- Map the `destination_schema` object (`name`, `table`, `table_group_name`).
- `Connector.destinationSchemaName()` resolves `destination_schema.name` -> legacy `schema` -> `name`.
- `Status` asset id now uses the stable schema, e.g. `groupId.google_sheets`.

Note: asset ids shift from the old name-derived value (`groupId.google_sheets_destination`) to the correct schema-based one (`groupId.google_sheets`).

Verified against the live v2 API. 57 tests pass, build + doc-lint green.